### PR TITLE
Add GitHub files, copyright and License information

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,94 @@
+# Code of Conduct
+
+This code of conduct applies to the maintainers and contributors alike.
+
+## Dealing with issues and support requests
+
+_We wish to add a specific section on dealing with issues opened against the
+repository here._
+
+This repository exists in the context of EGI Operations. While that scope does
+not restrict the usage, it does inform the priority we assign to issues and the
+order we deal with them.
+
+We welcome issues reported by the public, and more specifically the community
+of people using this repository.
+The EGI operations team is small and cannot support all requests equally.
+While we undertake to do everything in our power to respond to issues
+timeously, and to prioritise issues based on reasonable requests from
+submitters, the maintainers expect that the prioritisation of issues as decided
+by them is respected.
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age,
+body size, disability, ethnicity, gender identity and expression, level of
+experience, nationality, personal appearance, race, religion, or sexual
+identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event. Representation of a
+project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at contact@egi.eu. The project team
+will review and investigate all complaints, and will respond in a way that it
+deems appropriate to the circumstances. The project team is obligated to
+maintain confidentiality with regard to the reporter of an incident. Further
+details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+[http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -7,15 +7,15 @@ This code of conduct applies to the maintainers and contributors alike.
 _We wish to add a specific section on dealing with issues opened against the
 repository here._
 
-This repository exists in the context of EGI Operations. While that scope does
+This repository exists in the context of the EGI Federation. While that scope does
 not restrict the usage, it does inform the priority we assign to issues and the
 order we deal with them.
 
 We welcome issues reported by the public, and more specifically the community
 of people using this repository.
-The EGI operations team is small and cannot support all requests equally.
+The EGI team is small and cannot support all requests equally.
 While we undertake to do everything in our power to respond to issues
-timeously, and to prioritise issues based on reasonable requests from
+timely, and to prioritise issues based on reasonable requests from
 submitters, the maintainers expect that the prioritisation of issues as decided
 by them is respected.
 
@@ -74,9 +74,9 @@ project may be further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at contact@egi.eu. The project team
+reported by contacting the EGI Foundation team at contact@egi.eu. The team
 will review and investigate all complaints, and will respond in a way that it
-deems appropriate to the circumstances. The project team is obligated to
+deems appropriate to the circumstances. The team is obligated to
 maintain confidentiality with regard to the reporter of an incident. Further
 details of specific enforcement policies may be posted separately.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,98 @@
+# Contributing
+
+Thank you for taking the time to contribute to this project.
+The maintainers greatly appreciate the interest of contributors and rely on
+continued engagement with the community to ensure that this project remains
+useful.
+We would like to take steps to put contributors in the best possible position
+to have their contributions accepted.
+Please take a few moments to read this short guide on how to contribute; bear
+in mind that contributions regarding how to best contribute are also welcome.
+
+## Feedback and Questions
+
+If you wish to discuss anything related to the project, please open an issue or
+start a topic on the [EGI Community Forum](https://community.egi.eu).
+The maintainers will sometimes move issues off of GitHub to the community forum
+if it is thought that longer, more open-ended discussion would be beneficial,
+including a wider community scope.
+
+## Contribution Process
+
+Before proposing a contribution via pull request, ideally there is an open
+issue describing the need for your contribution (refer to this issue number
+when you submit the pull request). We have a 3 step process for contributions.
+
+  1. Fork the project if you have not, and commit changes to a git branch
+  1. Create a GitHub Pull Request for your change, following the instructions
+     in the pull request template.
+  1. Perform a [Code Review](#code-review-process) with the maintainers on the
+     pull request.
+
+### Pull Request Requirements
+
+  1. **Explain your contribution in plain language.** To assist the maintainers
+     in understanding and appreciating your pull request, please use the
+     template to explain _why_ you are making this contribution, rather than
+     just _what_ the contribution entails.
+
+### Code Review Process
+
+Code review takes place in GitHub pull requests. See [this
+article](https://help.github.com/articles/about-pull-requests/) if you're not
+familiar with GitHub Pull Requests.
+
+Once you open a pull request, maintainers will review your code using the
+built-in code review process in Github PRs. The process at this point is as
+follows:
+
+1. A maintainer will review your code and merge it if no changes are necessary.
+   Your change will be merged into the repository's `master` branch.
+1. If a maintainer has feedback or questions on your changes they they will set
+   `request changes` in the review and provide an explanation.
+
+## Using git
+
+For collaboration purposes, it is best if you create a GitHub account and fork
+the repository to your own account. Once you do this you will be able to push
+your changes to your GitHub repository for others to see and use, and it will
+be easier to send pull requests.
+
+### Branches and Commits
+
+You should submit your patch as a git branch named after the Github issue, such
+as `#3`\. This is called a _topic branch_ and allows users to associate a
+branch of code with the ticket.
+
+It is a best practice to have your commit message have a _summary line_ that
+includes the ticket number, followed by an empty line and then a brief
+description of the commit. This also helps other contributors understand the
+purpose of changes to the code.
+
+```text
+    #3 - platform_family and style
+
+    * use platform_family for platform checking
+    * update notifies syntax to "resource_type[resource_name]" instead of
+      resources() lookup
+    * GH-692 - delete config files dropped off by packages in conf.d
+    * dropped debian 4 support because all other platforms have the same
+      values, and it is older than "old stable" debian release
+```
+
+## Release cycle
+
+Master branch is always available.
+Tagged versions may be created as needed following [Semantic
+Versioning](https://semver.org/) as far as applicable.
+
+## Community
+
+EGI benefits from a strong community of developers and system administrators,
+and vice-versa. If you have any questions or if you would like to get involved
+in the wider EGI community you can check out:
+
+- [EGI Community Forum](https://community.egi.eu/)
+- [EGI website](https://www.egi.eu)
+
+**This file has been modified from the Chef Cookbook Contributing Guide**.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -62,10 +62,10 @@ be easier to send pull requests.
 
 You should submit your patch as a git branch named after the Github issue, such
 as `#3`\. This is called a _topic branch_ and allows users to associate a
-branch of code with the ticket.
+branch of code with the issue.
 
 It is a best practice to have your commit message have a _summary line_ that
-includes the ticket number, followed by an empty line and then a brief
+includes the issue number, followed by an empty line and then a brief
 description of the commit. This also helps other contributors understand the
 purpose of changes to the code.
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!--
+Thank you for opening an issue in our documentation.
+Please use the template below to construct the issue.
+
+Dealing with issues:
+- Issues opened here will be evaluated by the maintainers, and given priority based
+  based on that evaluation.
+- Support is provided on a best-effort basis
+- See the CODE_OF_CONDUCT.md for a deeper description of how we deal with support
+  and issues.
+-->
+
+# Short Description of the issue
+
+<!-- 
+Please provide a plain-language description of what you would like to report.
+By using simple, concise language, you can help the maintainers understand the
+issue and context, and thereby help them prioritise it.
+-->
+
+<!-- the section below is optional - remove it if you don't know what to propose,
+but merely want to report an issue.  -->
+
+# Summary of proposed changes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+<!--
+A good PR should describe what benefit this brings to the repository.
+Ideally, there is an existing issue which the PR address.
+-->
+
+# Summary 
+
+<!-- Describe in plain English what this PR does -->
+
+----
+<!-- Add the related issue here, e.g. #6 -->
+**Related issue :**

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,8 @@
+Maintainers
+-----------
+Baptiste Grenier <baptiste.grenier@egi.eu>
+
+Contributors
+------------
+Enol Fernandez <enol.fernandez@egi.eu>
+Baptiste Grenier <baptiste.grenier@egi.eu>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,8 +1,7 @@
 Maintainers
 -----------
-Baptiste Grenier <baptiste.grenier@egi.eu>
+Full Name <email>
 
 Contributors
 ------------
-Enol Fernandez <enol.fernandez@egi.eu>
-Baptiste Grenier <baptiste.grenier@egi.eu>
+Full Name <email>

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,4 @@
+This project is licensed under MIT.
+
+Copyrights in this project are retained by their contributors.
+No copyright assignment is required to contribute to this project.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 EGI Foundation
+Copyright (c) 2019 The authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
-# repository-template
-Template for repository
+# Template for EGI repositories.
+
+It includes:
+
+* License information
+* Copyright and author information
+* Code of conduct and contribution guidelines
+* Templates for PR and issues
+
+Content is based on:
+
+* [Contributor Covenant](http://contributor-covenant.org)
+* [Semantic Versioning](https://semver.org/)
+* [Chef Cookbook Contributing Guide](https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD)


### PR DESCRIPTION
Add GitHub files, copyright and License information to be used as templates for other projects.