### PR TITLE
Rename EGI-Foundation org to EGI-Federation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,4 +7,4 @@
 # These owners will be the default owners for everything in the repo.
 # Unless a later match takes precedence, they will be requested for
 # review when someone opens a pull request.
-* @EGI-Foundation/admins @EGI-Foundation/operations
+* @EGI-Federation/admins @EGI-Federation/operations

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Content is based on:
 ## Asking for creation of a repository
 
 It can be done by contacting the
-[administrators](https://github.com/orgs/EGI-Foundation/teams/admins).
+[administrators](https://github.com/orgs/EGI-Federation/teams/admins).
 
 The following information should be provided:
 
@@ -59,8 +59,8 @@ To be configured on the repository settings.
 ## Access
 
 All access should be managed via
-[GitHub teams](https://github.com/orgs/EGI-Foundation/teams).
+[GitHub teams](https://github.com/orgs/EGI-Federation/teams).
 
-- EGI-Foundation/admins: administration right
+- EGI-Federation/admins: administration right
 - Others participants depending on the requirement: maintain, triage or write or
   rights

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Template for EGI repositories.
+# Template for EGI repositories
 
 It includes:
 


### PR DESCRIPTION
Update references to EGI-Foundation, and use EGI-Federation as the GitHub organisation has been renamed.
