### PR TITLE
lint: do full checkout

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,9 @@ jobs:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          # Full git history needed to get proper list of changed files
+          fetch-depth: 0
 
       # Runs the Super-Linter action
       - name: Run Super-Linter on new changes


### PR DESCRIPTION
lint: do full checkout to avoid problem with super-linter not finding proper commit changes by looking at the history